### PR TITLE
하단 버튼 컴포넌트 styled-compoents 코드 수정

### DIFF
--- a/src/components/buttons/BottomBtn.tsx
+++ b/src/components/buttons/BottomBtn.tsx
@@ -2,11 +2,9 @@
 import { ButtonHTMLAttributes, ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 
-type BtnStatus = 'active' | 'disabled';
-
-export interface BtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface BtnPropsType extends ButtonHTMLAttributes<HTMLButtonElement> {
   className?: string;
-  status?: BtnStatus;
+  btnstatus?: 'active' | 'disabled';
   width?: string;
   height?: string;
   borderRadius?: string;
@@ -15,52 +13,7 @@ export interface BtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
 }
 
-export const BottomBtn = ({
-  className,
-  handleClick,
-  children,
-  ...props
-}: BtnProps) => {
-  return (
-    <BottomBtnWrapper className={className} onClick={handleClick} {...props}>
-      {children}
-    </BottomBtnWrapper>
-  );
-};
-
-const statusStyle = css<BtnProps>`
-  ${({ status = 'active' }) => {
-    if (status === 'active') {
-      return css`
-        background-color: ${({ theme }) => theme.colors.green};
-        color: white;
-        &:hover {
-          background-color: ${({ theme }) => theme.colors.green_dark};
-          cursor: pointer;
-        }
-      `;
-    }
-    if (status === 'disabled') {
-      return css`
-        background-color: rgba(133, 136, 153, 0.08);
-        color: #525463;
-      `;
-    }
-  }}
-`;
-
-const BottomBtnWrapper = styled.button<BtnProps>`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-
-  user-select: none;
-
-  transition: background-color 0.1s ease;
-
-  font-family: 'PretendardMedium';
-
+const BtnCustomStyle = css<BtnPropsType>`
   ${({
     width = '360px',
     height = '52px',
@@ -72,6 +25,47 @@ const BottomBtnWrapper = styled.button<BtnProps>`
     border-radius: ${borderRadius};
     font-size: ${fontSize};
   `};
-
-  ${statusStyle};
 `;
+
+const BtnStatusStyle = css<BtnPropsType>`
+  background-color: ${({ theme }) => theme.colors.green};
+  color: white;
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.green_dark};
+    cursor: pointer;
+  }
+  &.disabled {
+    background-color: rgba(133, 136, 153, 0.08);
+    color: #525463;
+    cursor: default;
+  }
+`;
+
+const BtnBase = styled.button<BtnPropsType>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+
+  user-select: none;
+
+  transition: background-color 0.1s ease;
+
+  font-family: 'PretendardMedium';
+
+  ${BtnCustomStyle}
+  ${BtnStatusStyle}
+`;
+
+export const BottomBtn = ({
+  className,
+  handleClick,
+  children,
+  ...props
+}: BtnPropsType) => {
+  return (
+    <BtnBase className={className} onClick={handleClick} {...props}>
+      {children}
+    </BtnBase>
+  );
+};

--- a/src/components/write/WriteArea.tsx
+++ b/src/components/write/WriteArea.tsx
@@ -24,7 +24,7 @@ export const WriteArea = () => {
       <MaxLengthText>최대 100자</MaxLengthText>
       <CompleteBtn
         type="submit"
-        status={text.length > 0 ? 'active' : 'disabled'}
+        className={text.length > 0 ? 'active' : 'disabled'}
       >
         입력완료
       </CompleteBtn>


### PR DESCRIPTION
## Issue
#10 

## 작업 내용
- 하단 버튼 컴포넌트 재사용 가능하도록 함
- 기본 커스텀 스타일, status에 따른 스타일 분리
- styled-components warning 때문에 className으로 status 지정하는 것으로 변경

## 참고 사항

## 📸 스크린샷
