### PR TITLE
recoil 도입 / 진행률 전역 상태로 관리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.2",
+        "recoil": "^0.7.7",
         "styled-components": "^6.0.5",
         "vite-tsconfig-paths": "^4.2.0"
       },
@@ -4545,6 +4546,11 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5670,6 +5676,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/regenerate": {
@@ -9688,6 +9713,11 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -10433,6 +10463,14 @@
       "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "regenerate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ggumtle_frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@emotion/is-prop-valid": "^1.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emotion/is-prop-valid": "^1.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2",
+    "recoil": "^0.7.7",
     "styled-components": "^6.0.5",
     "vite-tsconfig-paths": "^4.2.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
+import { StyleSheetManager } from 'styled-components';
+import isPropValid from '@emotion/is-prop-valid';
 import { GlobalStyle } from '@styles/global-style';
 import GlobalFonts from '@assets/fonts';
 
@@ -9,16 +12,20 @@ import { WritePage } from '@pages/Write';
 
 function App() {
   return (
-    <BrowserRouter>
-      <GlobalStyle />
-      <GlobalFonts />
-      <Layout>
-        <Routes>
-          <Route path={'/'} element={<LandingPage />} />
-          <Route path={'/write'} element={<WritePage />} />
-        </Routes>
-      </Layout>
-    </BrowserRouter>
+    <RecoilRoot>
+      <StyleSheetManager shouldForwardProp={isPropValid}>
+        <BrowserRouter>
+          <GlobalStyle />
+          <GlobalFonts />
+          <Layout>
+            <Routes>
+              <Route path={'/'} element={<LandingPage />} />
+              <Route path={'/write'} element={<WritePage />} />
+            </Routes>
+          </Layout>
+        </BrowserRouter>
+      </StyleSheetManager>
+    </RecoilRoot>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,10 @@ import GlobalFonts from '@assets/fonts';
 
 import { Layout } from '@components/layout';
 
+//pages
 import { LandingPage } from '@pages/Landing';
 import { WritePage } from '@pages/Write';
+import { UserInfoPage } from '@pages/UserInfo';
 
 function App() {
   return (
@@ -21,6 +23,7 @@ function App() {
             <Routes>
               <Route path={'/'} element={<LandingPage />} />
               <Route path={'/write'} element={<WritePage />} />
+              <Route path={'/userinfo'} element={<UserInfoPage />} />
             </Routes>
           </Layout>
         </BrowserRouter>

--- a/src/components/common/Progressbar/ProgressLine.tsx
+++ b/src/components/common/Progressbar/ProgressLine.tsx
@@ -33,7 +33,7 @@ const fillAnimation = keyframes`
   }
 `;
 
-export const CompletedLine = styled.div<{ progress?: number }>`
+const CompletedLine = styled.div<{ progress?: number }>`
   width: ${(props) => props.progress || 0}%;
   height: 3px;
 

--- a/src/components/common/Progressbar/ProgressLine.tsx
+++ b/src/components/common/Progressbar/ProgressLine.tsx
@@ -1,9 +1,10 @@
 import styled, { keyframes } from 'styled-components';
+import { useRecoilValue } from 'recoil';
+import { progressState } from '@recoil/progress';
 
-interface PropsType {
-  progress?: number;
-}
-export const ProgressLine = ({ progress }: PropsType) => {
+export const ProgressLine = () => {
+  const progress = useRecoilValue<number>(progressState);
+
   return (
     <>
       <BackgroundLine />
@@ -28,11 +29,11 @@ const fillAnimation = keyframes`
     width: 0;
   }
   to {
-    width: ${(props: PropsType) => (props.progress || 0) + '%'};
+    width: ${(progress) => (progress || 0) + '%'};
   }
 `;
 
-const CompletedLine = styled.div<{ progress?: number }>`
+export const CompletedLine = styled.div<{ progress?: number }>`
   width: ${(props) => props.progress || 0}%;
   height: 3px;
 

--- a/src/components/common/Progressbar/ProgressLine.tsx
+++ b/src/components/common/Progressbar/ProgressLine.tsx
@@ -33,7 +33,7 @@ const fillAnimation = keyframes`
   }
 `;
 
-const CompletedLine = styled.div<{ progress?: number }>`
+const CompletedLine = styled.div<{ progress: number }>`
   width: ${(props) => props.progress || 0}%;
   height: 3px;
 
@@ -42,6 +42,6 @@ const CompletedLine = styled.div<{ progress?: number }>`
   transform: translate(0, -50%);
 
   background: ${({ theme }) => theme.colors.green};
-  animation: ${fillAnimation} ${({ progress = 0 }) => 0.1 * (progress / 10)}s
-    linear forwards;
+  animation: ${fillAnimation} ${({ progress }) => 0.2 * (progress / 10)}s linear
+    forwards;
 `;

--- a/src/components/common/Progressbar/ProgressbarWrapper.tsx
+++ b/src/components/common/Progressbar/ProgressbarWrapper.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const ProgressbarWrapper = styled.div`
+  margin-top: 30px;
+`;

--- a/src/components/common/Progressbar/index.tsx
+++ b/src/components/common/Progressbar/index.tsx
@@ -3,13 +3,10 @@ import styled from 'styled-components';
 import { ProgressLine } from './ProgressLine';
 import { ProgressCircle } from './ProgressCircle';
 
-interface ProgressbarProps {
-  progress: number;
-}
-export const Progressbar = ({ progress }: ProgressbarProps) => {
+export const Progressbar = () => {
   return (
     <ProgressbarContainer>
-      <ProgressLine progress={progress} />
+      <ProgressLine />
       <ProgressCircle size="28px" step={1} status="complete" />
       <ProgressCircle size="28px" step={2} />
     </ProgressbarContainer>

--- a/src/components/write/WriteArea.tsx
+++ b/src/components/write/WriteArea.tsx
@@ -1,28 +1,30 @@
 import styled from 'styled-components';
 import { useState, FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import { useSetRecoilState } from 'recoil';
-import { progressState } from '@recoil/progress';
+import { useProgress } from '@hooks/useProgress';
 
 import { BottomBtn } from '@components/common/Buttons/BottomBtn';
 
-export const WriteArea = () => {
+export function WriteArea() {
+  const navigate = useNavigate();
+  const updateProgress = useProgress();
+
   const [text, setText] = useState('');
-  const setProgress = useSetRecoilState(progressState);
 
   const handleChangeTextBox = (e: FormEvent<HTMLTextAreaElement>) => {
     setText(e.currentTarget.value);
     if (e.currentTarget.value.length === 0) {
-      setProgress(0);
+      updateProgress(0);
     } else if (e.currentTarget.value.length > 0) {
-      setProgress(50);
+      updateProgress(50);
     }
   };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (text.length > 0) {
-      console.log('제출');
+      navigate('/userinfo');
     }
   };
 
@@ -44,7 +46,7 @@ export const WriteArea = () => {
       </CompleteBtn>
     </WriteAreaContainer>
   );
-};
+}
 
 const WriteAreaContainer = styled.form`
   width: 100%;

--- a/src/components/write/WriteArea.tsx
+++ b/src/components/write/WriteArea.tsx
@@ -1,9 +1,23 @@
 import styled from 'styled-components';
 import { useState, FormEvent } from 'react';
+
+import { useSetRecoilState } from 'recoil';
+import { progressState } from '@recoil/progress';
+
 import { BottomBtn } from '@components/common/Buttons/BottomBtn';
 
 export const WriteArea = () => {
   const [text, setText] = useState('');
+  const setProgress = useSetRecoilState(progressState);
+
+  const handleChangeTextBox = (e: FormEvent<HTMLTextAreaElement>) => {
+    setText(e.currentTarget.value);
+    if (e.currentTarget.value.length === 0) {
+      setProgress(0);
+    } else if (e.currentTarget.value.length > 0) {
+      setProgress(50);
+    }
+  };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -18,7 +32,7 @@ export const WriteArea = () => {
         placeholder="내가 이루고 싶은 꿈은?"
         maxLength={100}
         value={text}
-        onChange={(e) => setText(e.target.value)}
+        onChange={handleChangeTextBox}
         className={text.length > 0 ? 'green' : ''}
       />
       <MaxLengthText>최대 100자</MaxLengthText>

--- a/src/hooks/useProgress.tsx
+++ b/src/hooks/useProgress.tsx
@@ -1,0 +1,10 @@
+import { useSetRecoilState } from 'recoil';
+import { progressState } from '@recoil/progress';
+
+export const useProgress = () => {
+  const setProgress = useSetRecoilState(progressState);
+
+  return (progress: number) => {
+    setProgress(progress);
+  };
+};

--- a/src/pages/UserInfo/index.tsx
+++ b/src/pages/UserInfo/index.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+import { ProgressbarWrapper } from '@components/common/Progressbar/ProgressbarWrapper';
+import { Progressbar } from '@components/common/Progressbar';
+
+import { useProgress } from '@hooks/useProgress';
+
+export const UserInfoPage = () => {
+  const updateProgress = useProgress();
+
+  useEffect(() => {
+    updateProgress(50);
+  }, []);
+
+  const handleClickBtn = () => {
+    updateProgress(100);
+  };
+
+  return (
+    <>
+      <ProgressbarWrapper>
+        <Progressbar />
+      </ProgressbarWrapper>
+
+      <div>유저 정보 입력</div>
+      <button onClick={handleClickBtn}>입력 완료</button>
+    </>
+  );
+};

--- a/src/pages/Write/index.tsx
+++ b/src/pages/Write/index.tsx
@@ -1,14 +1,25 @@
+import { styled } from 'styled-components';
+import { useEffect } from 'react';
+
 import { MainText } from '@components/write/MainText';
 import { WriteArea } from '@components/write/WriteArea';
+import { ProgressbarWrapper } from '@components/common/Progressbar/ProgressbarWrapper';
 import { Progressbar } from '@components/common/Progressbar';
-import { styled } from 'styled-components';
+
+import { useProgress } from '@hooks/useProgress';
 
 export const WritePage = () => {
+  const updateProgress = useProgress();
+
+  useEffect(() => {
+    updateProgress(0);
+  }, []);
+
   return (
     <WritePageContainer>
-      <ProgressbarContainer>
+      <ProgressbarWrapper>
         <Progressbar />
-      </ProgressbarContainer>
+      </ProgressbarWrapper>
       <MainText />
       <WriteArea />
     </WritePageContainer>
@@ -19,8 +30,4 @@ const WritePageContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-`;
-
-const ProgressbarContainer = styled.div`
-  margin-top: 30px;
 `;

--- a/src/pages/Write/index.tsx
+++ b/src/pages/Write/index.tsx
@@ -7,7 +7,7 @@ export const WritePage = () => {
   return (
     <WritePageContainer>
       <ProgressbarContainer>
-        <Progressbar progress={50} />
+        <Progressbar />
       </ProgressbarContainer>
       <MainText />
       <WriteArea />

--- a/src/recoil/progress.ts
+++ b/src/recoil/progress.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+
+//progressbar의 진행률(%)
+export const progressState = atom<number>({
+  key: 'progressState',
+  default: 0,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
       "@components/*": ["src/components/*"],
       "@hooks/*": ["src/hooks/*"],
       "@pages/*": ["src/pages/*"],
-      "@styles/*": ["src/styles/*"]
+      "@styles/*": ["src/styles/*"],
+      "@recoil/*": ["src/recoil/*"]
     },
 
     /* Bundler mode */


### PR DESCRIPTION
## Issue
#4 

## 작업 내용
- recoil 설치 및 적용 (src/reocil) 
- 진행률 `progressState` atom으로 관리
- `useProgress` hook으로 진행률 업데이트 -> 정보 입력 페이지에서 사용

## 참고 사항

## 📸 스크린샷

<img width="320" alt="image" src="https://github.com/our-bbang/ggumtle_frontend/assets/70098708/e21259c1-f1cc-4b76-8958-f5b7f629ed6b">

