### PR TITLE
유저가 입력했던 정보 새로 고침해도 유지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.2",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "styled-components": "^6.0.5",
         "vite-tsconfig-paths": "^4.2.0"
       },
@@ -6901,6 +6902,14 @@
         }
       }
     },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -12820,6 +12829,12 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
+    },
+    "recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "styled-components": "^6.0.5",
     "vite-tsconfig-paths": "^4.2.0"
   },

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -6,11 +6,9 @@ interface UserInfo {
   job: string;
 }
 export const getMandalartPlan = async (goal: string, userinfo: UserInfo) => {
-  const { data } = await client.get('/plan', {
-    data: {
-      goal,
-      userinfo,
-    },
+  const { data } = await client.post('/plan', {
+    goal,
+    ...userinfo,
   });
   return data;
 };

--- a/src/components/landing/ResetAtoms.tsx
+++ b/src/components/landing/ResetAtoms.tsx
@@ -1,0 +1,20 @@
+import { useResetRecoilState } from 'recoil';
+import { goalState } from '@recoil/goal';
+import { genderState, ageState, jobState } from '@recoil/userinput';
+import { useEffect } from 'react';
+
+export const ResetAtoms = () => {
+  const resetGoal = useResetRecoilState(goalState);
+  const resetGender = useResetRecoilState(genderState);
+  const resetAge = useResetRecoilState(ageState);
+  const resetJob = useResetRecoilState(jobState);
+
+  useEffect(() => {
+    resetGoal();
+    resetGender();
+    resetAge();
+    resetJob();
+  }, []);
+
+  return <></>;
+};

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -5,6 +5,8 @@ import { MainLogo } from '@components/landing/MainLogo';
 import { BtnBottomContainer } from '@components/common/Buttons/BtnBottomContainer';
 import { BottomBtn } from '@components/common/Buttons/BottomBtn';
 
+import { ResetAtoms } from '@components/landing/ResetAtoms';
+
 export const LandingPage = () => {
   const navigate = useNavigate();
 
@@ -14,6 +16,7 @@ export const LandingPage = () => {
 
   return (
     <LandingPageContainer>
+      <ResetAtoms />
       <MainLogo />
       <Box>추가 설명</Box>
       <BtnBottomContainer>

--- a/src/recoil/goal.ts
+++ b/src/recoil/goal.ts
@@ -1,6 +1,8 @@
 import { atom } from 'recoil';
+import { persistAtom } from './persist';
 
 export const goalState = atom<string>({
   key: 'goalState',
   default: '',
+  effects_UNSTABLE: [persistAtom],
 });

--- a/src/recoil/persist.ts
+++ b/src/recoil/persist.ts
@@ -1,0 +1,3 @@
+import { recoilPersist } from 'recoil-persist';
+
+export const { persistAtom } = recoilPersist();

--- a/src/recoil/userinput.ts
+++ b/src/recoil/userinput.ts
@@ -1,4 +1,5 @@
 import { atom, selector } from 'recoil';
+import { persistAtom } from './persist';
 
 export enum Gender {
   Male = 1,
@@ -7,16 +8,19 @@ export enum Gender {
 export const genderState = atom<Gender.Male | Gender.Female | 0>({
   key: 'genderState',
   default: 0,
+  effects_UNSTABLE: [persistAtom],
 });
 
 export const ageState = atom<number | string>({
   key: 'ageState',
   default: 20,
+  effects_UNSTABLE: [persistAtom],
 });
 
 export const jobState = atom<string>({
   key: 'jobState',
   default: '',
+  effects_UNSTABLE: [persistAtom],
 });
 
 export const isUserInfoCompletedSelector = selector({


### PR DESCRIPTION
## Issue
#31 

## 작업 내용
- recoil-persist 설치
- 목표, 유저가 입력한 정보(성별, 나이, 직업) atom에 recoil-persist 적용 -> localStorage에 적용함
- 랜딩 페이지로 돌아갈 시 atom들 defaultValue로 설정(`ResetAtoms` 컴포넌트)

## 참고 사항

## 📸 스크린샷
